### PR TITLE
[Feat] Spring MVC 예외처리 -> ResponseEntityExceptionHandler 상속받아 해결

### DIFF
--- a/adam/src/main/java/com/finance/adam/exception/GlobalExceptionHandler.java
+++ b/adam/src/main/java/com/finance/adam/exception/GlobalExceptionHandler.java
@@ -1,57 +1,25 @@
 package com.finance.adam.exception;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
-import org.springframework.web.HttpRequestMethodNotSupportedException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
-
-import java.util.HashMap;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
-public class GlobalExceptionHandler {
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseEntity> handleServerException(Exception e){
+        log.error("error occur : ", e);
         return ErrorResponseEntity.toResponseEntity(ErrorCode.SERVER_ERROR);
-    }
-
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ErrorResponseEntity> handleNoResourceFoundException(NoResourceFoundException e){
-        return ErrorResponseEntity.toResponseEntity(ErrorCode.NOT_FOUND);
     }
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponseEntity> handleCustomException(CustomException e){
         return ErrorResponseEntity.toResponseEntity(e.getErrorCode());
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        BindingResult result = e.getBindingResult();
-        HashMap<String,String> errMessage = new HashMap<>();
-
-        for (FieldError error : result.getFieldErrors()) {
-            errMessage.put(error.getField(), error.getDefaultMessage());
-        }
-
-        return new ResponseEntity<>(errMessage , HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity handleMethodNotAllowedException() {
-        return ErrorResponseEntity.toResponseEntity(ErrorCode.NOT_ALLOWED_METHOD);
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity handleHttpMessageNotReadableException() {
-        return ErrorResponseEntity.toResponseEntity(ErrorCode.BAD_REQUEST);
     }
 
     @ExceptionHandler(JsonParseException.class)

--- a/adam/src/main/resources/logback-spring.xml
+++ b/adam/src/main/resources/logback-spring.xml
@@ -35,4 +35,7 @@
         <appender-ref ref="FILE" />
     </root>
 
+    <!-- NoResourceFoundException 예외에 대한 WARN 로깅 제외 -->
+    <logger name="org.springframework.web" level="ERROR" />
+
 </configuration>

--- a/adam/src/test/java/com/finance/adam/exception/GlobalExceptionHandlerTest.java
+++ b/adam/src/test/java/com/finance/adam/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,42 @@
+package com.finance.adam.exception;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("api")
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    void testFinanceDataControllerGetApi() throws Exception {
+        mockMvc.perform(get("/api/v1/finances/stocks"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testHttpMediaTypeNotAcceptableException() throws Exception {
+        mockMvc.perform(get("/api/v1/finances/stocks")
+                .accept(MediaType.APPLICATION_XML_VALUE))
+                .andExpect(status().isNotAcceptable());
+    }
+}


### PR DESCRIPTION
- 기본적인 Spring MVC 예외는 프레임워크에서 제공하는 핸들러를 사용
- 메서드 오버라이드하여 세부적인 핸들러 커스텀 사용 가능